### PR TITLE
Restore YAML front matter on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,21 +1,14 @@
- (cd "$(git rev-parse --show-toplevel)" && git apply --3way <<'EOF' 
-diff --git a/index.html b/index.html
-index a8a1980d4389dd11d4baa138a8462947f8c45ed9..70e57c1cbc3d455b219e94ff46a192a656bd5e38 100644
---- a/index.html
-+++ b/index.html
-@@ -1,152 +1,470 @@
- ---
--layout: none
-+layout: null
-+permalink: /
- ---
-+{%- assign list_months = site.months | sort: "date" | reverse -%}
-+{%- if site.weeks -%}
-+  {%- assign list_weeks = site.weeks | sort: "date" | reverse -%}
-+{%- else -%}
-+  {%- assign list_weeks = "" | split: "" -%}
-+{%- endif -%}
-+{%- assign issues = list_months | concat: list_weeks -%}
+---
+layout: none
+permalink: /
+---
+{%- assign list_months = site.months | sort: "date" | reverse -%}
+{%- if site.weeks -%}
+  {%- assign list_weeks = site.weeks | sort: "date" | reverse -%}
+{%- else -%}
+  {%- assign list_weeks = "" | split: "" -%}
+{%- endif -%}
+{%- assign issues = list_months | concat: list_weeks -%}
  <!doctype html>
  <html lang="vi">
  <head>
@@ -32,547 +25,447 @@ index a8a1980d4389dd11d4baa138a8462947f8c45ed9..70e57c1cbc3d455b219e94ff46a192a6
  <script src="https://unpkg.com/@phosphor-icons/web"></script>
  
  <style>
--  :root{--agr:#065f46; --agr-2:#064e3b; --chip:#ecfdf5; --chipb:#10b981; --bg:#f7fee7; --line:#bbf7d0; --card:#ffffff;}
-+  :root{
-+    --bg:#f5fbf7;
-+    --bg-secondary:#f0fdf4;
-+    --surface:#ffffff;
-+    --surface-muted:#f4fce3;
-+    --primary:#047857;
-+    --primary-dark:#064e3b;
-+    --accent:#10b981;
-+    --border:#bbf7d0;
-+    --shadow:0 24px 60px -40px rgba(6,95,70,0.65);
-+  }
+  :root{
+    --bg:#f5fbf7;
+    --bg-secondary:#f0fdf4;
+    --surface:#ffffff;
+    --surface-muted:#f4fce3;
+    --primary:#047857;
+    --primary-dark:#064e3b;
+    --accent:#10b981;
+    --border:#bbf7d0;
+    --shadow:0 24px 60px -40px rgba(6,95,70,0.65);
+  }
    *{box-sizing:border-box}
--  html,body{height:100%}
--  body{font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;background:var(--bg);margin:0;color:#0f172a}
--  .wrap{max-width:1120px;margin:0 auto;padding:28px 16px 52px}
--  .hero{ text-align:center;margin:0 0 18px; padding:26px 14px 22px;
--         background:linear-gradient(180deg, #f0fdf4 0%, #f7fee7 100%);
--         border:1px solid var(--line); border-radius:18px; }
--  .title{font-size:clamp(28px,4.8vw,46px);color:var(--agr-2);margin:0;font-weight:800;letter-spacing:-.02em}
--  .subtitle{color:#166534;font-size:clamp(16px,3.6vw,20px);opacity:.95;margin-top:6px}
--  .controls{display:flex;justify-content:center;gap:10px;margin:14px 0 6px}
--  .btn{border:1px solid var(--chipb);background:var(--chip);color:var(--agr);border-radius:999px;padding:.45rem .85rem;font-weight:800;cursor:pointer}
--  .btn[aria-pressed="true"]{background:var(--agr);color:#ecfdf5;border-color:var(--agr)}
--  .viewer{background:var(--card);border:1px solid var(--line);border-radius:18px;padding:14px;min-height:260px;box-shadow:0 10px 18px rgba(22,163,74,.08)}
--  .viewer .inner{padding:6px 6px 10px}
--  .skeleton{height:11px;background:#e3f4ea;border-radius:6px;margin:9px 0;animation:pulse 1.1s infinite ease-in-out}
--  @keyframes pulse{0%{opacity:.55}50%{opacity:1}100%{opacity:.55}}
--  /* Card grid */
--  .card{background:#fff;border:1px solid var(--line);border-radius:14px;padding:16px;box-shadow:0 10px 18px rgba(22,163,74,.08)}
--  .card:hover{transform:translateY(-1px);transition:.15s;box-shadow:0 14px 28px rgba(16,185,129,.18)}
--  .badge{display:inline-flex;align-items:center;gap:.35rem;background:#ecfdf5;border:1px solid #10b981;color:#065f46;padding:.28rem .55rem;border-radius:999px;font-weight:800;font-size:.82rem}
--  /* Compact mode */
--  body.compact .title{font-size:1.6rem}
-+  html,body{min-height:100%}
-+  body{
-+    margin:0;
-+    font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-+    color:var(--primary-dark);
-+    background:linear-gradient(155deg,var(--bg) 0%,#f8fff4 45%,#ecfdf5 100%);
-+  }
-+  .page{
-+    max-width:1200px;
-+    margin:0 auto;
-+    padding:32px 18px 72px;
-+  }
-+  .hero{
-+    display:grid;
-+    gap:32px;
-+    padding:36px 28px;
-+    margin-bottom:32px;
-+    border-radius:28px;
-+    background:linear-gradient(140deg,#ecfdf5 0%,#d1fae5 35%,#f8fafc 100%);
-+    border:1px solid rgba(16,185,129,.2);
-+    box-shadow:0 40px 80px -60px rgba(15,118,110,.5);
-+  }
-+  @media(min-width:960px){
-+    .hero{grid-template-columns:1fr 360px;align-items:center;padding:44px 52px;}
-+  }
-+  .hero__eyebrow{
-+    display:inline-flex;
-+    align-items:center;
-+    gap:.5rem;
-+    padding:.35rem .75rem;
-+    border-radius:999px;
-+    background:rgba(6,95,70,.08);
-+    color:var(--primary);
-+    font-size:.85rem;
-+    font-weight:700;
-+    letter-spacing:.04em;
-+    text-transform:uppercase;
-+  }
-+  .hero__title{
-+    margin:12px 0 0;
-+    font-size:clamp(32px,6vw,52px);
-+    font-weight:800;
-+    letter-spacing:-.03em;
-+    color:var(--primary-dark);
-+  }
-+  .hero__subtitle{
-+    margin-top:14px;
-+    font-size:clamp(16px,2.8vw,19px);
-+    color:#0f766e;
-+  }
-+  .hero__pills{
-+    display:flex;
-+    flex-wrap:wrap;
-+    gap:10px;
-+    margin-top:24px;
-+  }
-+  .pill{
-+    display:inline-flex;
-+    align-items:center;
-+    gap:.45rem;
-+    padding:.45rem .85rem;
-+    border-radius:999px;
-+    border:1px solid rgba(14,165,233,.0);
-+    background:rgba(255,255,255,.8);
-+    font-weight:700;
-+    color:var(--primary-dark);
-+    box-shadow:0 10px 22px -18px rgba(15,118,110,0.65);
-+  }
-+  .hero__panel{
-+    display:grid;
-+    gap:18px;
-+    background:rgba(255,255,255,.72);
-+    border-radius:22px;
-+    padding:24px 24px 26px;
-+    backdrop-filter:blur(16px);
-+    border:1px solid rgba(16,185,129,.25);
-+  }
-+  .panel__title{
-+    display:flex;
-+    align-items:center;
-+    justify-content:space-between;
-+    gap:1rem;
-+    font-weight:700;
-+    font-size:1.05rem;
-+    color:var(--primary-dark);
-+  }
-+  .mode-toggle{
-+    display:flex;
-+    background:var(--surface);
-+    padding:4px;
-+    border-radius:999px;
-+    border:1px solid rgba(16,185,129,.35);
-+    box-shadow:var(--shadow);
-+  }
-+  .mode-toggle button{
-+    appearance:none;
-+    border:0;
-+    background:none;
-+    padding:.45rem .8rem;
-+    border-radius:999px;
-+    font-weight:700;
-+    color:var(--primary-dark);
-+    cursor:pointer;
-+    display:inline-flex;
-+    align-items:center;
-+    gap:.4rem;
-+    transition:background .25s,color .25s;
-+  }
-+  .mode-toggle button[aria-pressed="true"]{
-+    background:var(--primary);
-+    color:#ecfdf5;
-+    box-shadow:0 12px 30px -16px rgba(5,150,105,.9);
-+  }
-+  .timeline{
-+    display:flex;
-+    flex-direction:column;
-+    gap:12px;
-+  }
-+  .timeline__item{
-+    display:flex;
-+    align-items:center;
-+    gap:12px;
-+    font-size:.92rem;
-+    color:#0f172a;
-+    opacity:.8;
-+  }
-+  .timeline__item strong{color:var(--primary-dark);}
-+  .issue-section{
-+    display:grid;
-+    gap:24px;
-+  }
-+  @media(min-width:960px){
-+    .issue-section{grid-template-columns:1fr 420px;align-items:flex-start;}
-+  }
-+  body.mode-compact .issue-grid{grid-template-columns:repeat(1,minmax(0,1fr));}
-+  .issue-grid{
-+    display:grid;
-+    gap:18px;
-+    grid-template-columns:repeat(auto-fill,minmax(260px,1fr));
-+  }
-+  .issue-card{
-+    position:relative;
-+    display:flex;
-+    flex-direction:column;
-+    gap:10px;
-+    padding:18px 18px 20px;
-+    border-radius:18px;
-+    text-decoration:none;
-+    background:var(--surface);
-+    border:1px solid rgba(13,148,136,.2);
-+    box-shadow:0 16px 32px -28px rgba(15,118,110,.9);
-+    color:inherit;
-+    transition:transform .25s, box-shadow .25s, border-color .25s;
-+  }
-+  .issue-card:hover{transform:translateY(-4px);box-shadow:0 30px 60px -44px rgba(6,95,70,.75);}
-+  .issue-card.is-active{border-color:var(--primary);box-shadow:0 30px 60px -40px rgba(5,150,105,.88);}
-+  .issue-card__meta{
-+    display:flex;
-+    align-items:center;
-+    gap:10px;
-+    font-size:.85rem;
-+    color:#047857;
-+    font-weight:700;
-+  }
-+  .issue-card__type{
-+    display:inline-flex;
-+    align-items:center;
-+    gap:.35rem;
-+    padding:.35rem .7rem;
-+    background:var(--surface-muted);
-+    border-radius:999px;
-+    border:1px solid rgba(16,185,129,.35);
-+    color:var(--primary-dark);
-+  }
-+  .issue-card__title{
-+    margin:0;
-+    font-size:1.05rem;
-+    font-weight:800;
-+    color:var(--primary-dark);
-+    line-height:1.35;
-+  }
-+  .issue-card__desc{
-+    margin:0;
-+    font-size:.92rem;
-+    color:#0f172a;
-+    opacity:.75;
-+    display:-webkit-box;
-+    -webkit-line-clamp:2;
-+    -webkit-box-orient:vertical;
-+    overflow:hidden;
-+  }
-+  .viewer{
-+    position:relative;
-+    border-radius:28px;
-+    padding:22px 24px 28px;
-+    background:var(--surface);
-+    border:1px solid rgba(13,148,136,.25);
-+    box-shadow:0 28px 65px -52px rgba(4,120,87,.9);
-+    min-height:320px;
-+  }
-+  .viewer__header{
-+    display:flex;
-+    justify-content:space-between;
-+    align-items:center;
-+    margin-bottom:18px;
-+  }
-+  .viewer__title{
-+    font-weight:800;
-+    font-size:1.15rem;
-+    display:flex;
-+    align-items:center;
-+    gap:.6rem;
-+    color:var(--primary-dark);
-+  }
-+  .viewer__meta{font-size:.85rem;color:#0f766e;}
-+  .viewer .inner{padding:4px 0 0;}
-+  .skeleton{height:11px;background:#d1fae5;border-radius:6px;margin:10px 0;animation:pulse 1.1s infinite ease-in-out}
-+  @keyframes pulse{0%{opacity:.45}50%{opacity:1}100%{opacity:.45}}
-+  .empty-state{
-+    padding:42px 28px;
-+    text-align:center;
-+    border-radius:22px;
-+    background:var(--surface);
-+    border:1px dashed rgba(16,185,129,.45);
-+    color:var(--primary-dark);
-+    box-shadow:0 20px 54px -48px rgba(6,95,70,.6);
-+    font-weight:600;
-+  }
-+  .empty-state i{font-size:1.8rem;color:var(--primary);display:block;margin-bottom:12px;}
-+  body.mode-compact .hero{grid-template-columns:1fr;}
-+  body.mode-compact .hero__panel{order:3;}
-+  body.mode-compact .issue-section{grid-template-columns:1fr;}
-+  body.mode-compact .issue-card{padding:16px 16px 18px;}
+  html,body{min-height:100%}
+  body{
+    margin:0;
+    font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+    color:var(--primary-dark);
+    background:linear-gradient(155deg,var(--bg) 0%,#f8fff4 45%,#ecfdf5 100%);
+  }
+  .page{
+    max-width:1200px;
+    margin:0 auto;
+    padding:32px 18px 72px;
+  }
+  .hero{
+    display:grid;
+    gap:32px;
+    padding:36px 28px;
+    margin-bottom:32px;
+    border-radius:28px;
+    background:linear-gradient(140deg,#ecfdf5 0%,#d1fae5 35%,#f8fafc 100%);
+    border:1px solid rgba(16,185,129,.2);
+    box-shadow:0 40px 80px -60px rgba(15,118,110,.5);
+  }
+  @media(min-width:960px){
+    .hero{grid-template-columns:1fr 360px;align-items:center;padding:44px 52px;}
+  }
+  .hero__eyebrow{
+    display:inline-flex;
+    align-items:center;
+    gap:.5rem;
+    padding:.35rem .75rem;
+    border-radius:999px;
+    background:rgba(6,95,70,.08);
+    color:var(--primary);
+    font-size:.85rem;
+    font-weight:700;
+    letter-spacing:.04em;
+    text-transform:uppercase;
+  }
+  .hero__title{
+    margin:12px 0 0;
+    font-size:clamp(32px,6vw,52px);
+    font-weight:800;
+    letter-spacing:-.03em;
+    color:var(--primary-dark);
+  }
+  .hero__subtitle{
+    margin-top:14px;
+    font-size:clamp(16px,2.8vw,19px);
+    color:#0f766e;
+  }
+  .hero__pills{
+    display:flex;
+    flex-wrap:wrap;
+    gap:10px;
+    margin-top:24px;
+  }
+  .pill{
+    display:inline-flex;
+    align-items:center;
+    gap:.45rem;
+    padding:.45rem .85rem;
+    border-radius:999px;
+    border:1px solid rgba(14,165,233,.0);
+    background:rgba(255,255,255,.8);
+    font-weight:700;
+    color:var(--primary-dark);
+    box-shadow:0 10px 22px -18px rgba(15,118,110,0.65);
+  }
+  .hero__panel{
+    display:grid;
+    gap:18px;
+    background:rgba(255,255,255,.72);
+    border-radius:22px;
+    padding:24px 24px 26px;
+    backdrop-filter:blur(16px);
+    border:1px solid rgba(16,185,129,.25);
+  }
+  .panel__title{
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+    gap:1rem;
+    font-weight:700;
+    font-size:1.05rem;
+    color:var(--primary-dark);
+  }
+  .mode-toggle{
+    display:flex;
+    background:var(--surface);
+    padding:4px;
+    border-radius:999px;
+    border:1px solid rgba(16,185,129,.35);
+    box-shadow:var(--shadow);
+  }
+  .mode-toggle button{
+    appearance:none;
+    border:0;
+    background:none;
+    padding:.45rem .8rem;
+    border-radius:999px;
+    font-weight:700;
+    color:var(--primary-dark);
+    cursor:pointer;
+    display:inline-flex;
+    align-items:center;
+    gap:.4rem;
+    transition:background .25s,color .25s;
+  }
+  .mode-toggle button[aria-pressed="true"]{
+    background:var(--primary);
+    color:#ecfdf5;
+    box-shadow:0 12px 30px -16px rgba(5,150,105,.9);
+  }
+  .timeline{
+    display:flex;
+    flex-direction:column;
+    gap:12px;
+  }
+  .timeline__item{
+    display:flex;
+    align-items:center;
+    gap:12px;
+    font-size:.92rem;
+    color:#0f172a;
+    opacity:.8;
+  }
+  .timeline__item strong{color:var(--primary-dark);}
+  .issue-section{
+    display:grid;
+    gap:24px;
+  }
+  @media(min-width:960px){
+    .issue-section{grid-template-columns:1fr 420px;align-items:flex-start;}
+  }
+  body.mode-compact .issue-grid{grid-template-columns:repeat(1,minmax(0,1fr));}
+  .issue-grid{
+    display:grid;
+    gap:18px;
+    grid-template-columns:repeat(auto-fill,minmax(260px,1fr));
+  }
+  .issue-card{
+    position:relative;
+    display:flex;
+    flex-direction:column;
+    gap:10px;
+    padding:18px 18px 20px;
+    border-radius:18px;
+    text-decoration:none;
+    background:var(--surface);
+    border:1px solid rgba(13,148,136,.2);
+    box-shadow:0 16px 32px -28px rgba(15,118,110,.9);
+    color:inherit;
+    transition:transform .25s, box-shadow .25s, border-color .25s;
+  }
+  .issue-card:hover{transform:translateY(-4px);box-shadow:0 30px 60px -44px rgba(6,95,70,.75);}
+  .issue-card.is-active{border-color:var(--primary);box-shadow:0 30px 60px -40px rgba(5,150,105,.88);}
+  .issue-card__meta{
+    display:flex;
+    align-items:center;
+    gap:10px;
+    font-size:.85rem;
+    color:#047857;
+    font-weight:700;
+  }
+  .issue-card__type{
+    display:inline-flex;
+    align-items:center;
+    gap:.35rem;
+    padding:.35rem .7rem;
+    background:var(--surface-muted);
+    border-radius:999px;
+    border:1px solid rgba(16,185,129,.35);
+    color:var(--primary-dark);
+  }
+  .issue-card__title{
+    margin:0;
+    font-size:1.05rem;
+    font-weight:800;
+    color:var(--primary-dark);
+    line-height:1.35;
+  }
+  .issue-card__desc{
+    margin:0;
+    font-size:.92rem;
+    color:#0f172a;
+    opacity:.75;
+    display:-webkit-box;
+    -webkit-line-clamp:2;
+    -webkit-box-orient:vertical;
+    overflow:hidden;
+  }
+  .viewer{
+    position:relative;
+    border-radius:28px;
+    padding:22px 24px 28px;
+    background:var(--surface);
+    border:1px solid rgba(13,148,136,.25);
+    box-shadow:0 28px 65px -52px rgba(4,120,87,.9);
+    min-height:320px;
+  }
+  .viewer__header{
+    display:flex;
+    justify-content:space-between;
+    align-items:center;
+    margin-bottom:18px;
+  }
+  .viewer__title{
+    font-weight:800;
+    font-size:1.15rem;
+    display:flex;
+    align-items:center;
+    gap:.6rem;
+    color:var(--primary-dark);
+  }
+  .viewer__meta{font-size:.85rem;color:#0f766e;}
+  .viewer .inner{padding:4px 0 0;}
+  .skeleton{height:11px;background:#d1fae5;border-radius:6px;margin:10px 0;animation:pulse 1.1s infinite ease-in-out}
+  @keyframes pulse{0%{opacity:.45}50%{opacity:1}100%{opacity:.45}}
+  .empty-state{
+    padding:42px 28px;
+    text-align:center;
+    border-radius:22px;
+    background:var(--surface);
+    border:1px dashed rgba(16,185,129,.45);
+    color:var(--primary-dark);
+    box-shadow:0 20px 54px -48px rgba(6,95,70,.6);
+    font-weight:600;
+  }
+  .empty-state i{font-size:1.8rem;color:var(--primary);display:block;margin-bottom:12px;}
+  body.mode-compact .hero{grid-template-columns:1fr;}
+  body.mode-compact .hero__panel{order:3;}
+  body.mode-compact .issue-section{grid-template-columns:1fr;}
+  body.mode-compact .issue-card{padding:16px 16px 18px;}
  </style>
  </head>
  <body>
--<div class="wrap">
-+<div class="page">
+<div class="page">
    <header class="hero">
--    <h1 class="title">Điểm tin nhanh Ngành Nông Nghiệp</h1>
--    <div class="subtitle">AgriS • Cập nhật định kỳ theo tháng/tuần</div>
--
--    <div class="controls">
--      <button id="btnMobile" type="button" aria-pressed="false" class="btn"><i class="ph ph-device-mobile"></i> Giao diện Mobile</button>
--      <button id="btnDesktop" type="button" aria-pressed="true"  class="btn"><i class="ph ph-desktop-tower"></i> Giao diện Máy tính</button>
-+    <div>
-+      <span class="hero__eyebrow"><i class="ph ph-plant"></i> AgriS Newswire</span>
-+      <h1 class="hero__title">Điểm tin nhanh Ngành Nông Nghiệp</h1>
-+      <p class="hero__subtitle">Tổng hợp dữ liệu, biểu đồ và insight chiến lược dành cho Ban Lãnh đạo AgriS. Cập nhật định kỳ theo tháng/tuần.</p>
-+      <div class="hero__pills">
-+        <span class="pill"><i class="ph ph-sparkle"></i> Executive snapshot</span>
-+        <span class="pill"><i class="ph ph-chart-line-up"></i> KPI + Mermaid chart</span>
-+        <span class="pill"><i class="ph ph-lightning"></i> Tải nhanh, xem tại chỗ</span>
-+      </div>
+    <div>
+      <span class="hero__eyebrow"><i class="ph ph-plant"></i> AgriS Newswire</span>
+      <h1 class="hero__title">Điểm tin nhanh Ngành Nông Nghiệp</h1>
+      <p class="hero__subtitle">Tổng hợp dữ liệu, biểu đồ và insight chiến lược dành cho Ban Lãnh đạo AgriS. Cập nhật định kỳ theo tháng/tuần.</p>
+      <div class="hero__pills">
+        <span class="pill"><i class="ph ph-sparkle"></i> Executive snapshot</span>
+        <span class="pill"><i class="ph ph-chart-line-up"></i> KPI + Mermaid chart</span>
+        <span class="pill"><i class="ph ph-lightning"></i> Tải nhanh, xem tại chỗ</span>
+      </div>
      </div>
--
--    <div class="flex items-center justify-center gap-2 text-sm text-emerald-800 mt-2">
--      <span class="badge"><i class="ph ph-calendar-check"></i> Chọn bản điểm tin</span>
-+    <div class="hero__panel">
-+      <div class="panel__title">
-+        <span><i class="ph ph-calendar-check"></i> Chọn bản tin</span>
-+        <div class="mode-toggle" role="group" aria-label="Chế độ hiển thị">
-+          <button type="button" id="btnCompact" aria-pressed="false" data-mode="compact"><i class="ph ph-device-mobile"></i> Compact</button>
-+          <button type="button" id="btnComfort" aria-pressed="true" data-mode="comfort"><i class="ph ph-desktop-tower"></i> Comfort</button>
-+        </div>
-+      </div>
-+      <div class="timeline" id="issueTimeline">
-+        {%- if issues.size > 0 -%}
-+          {%- for it in issues limit:4 -%}
-+            {%- assign is_month = it.type == "month" or it.layout == "month" -%}
-+            <div class="timeline__item">
-+              <i class="ph ph-caret-right"></i>
-+              <div>
-+                <strong>{% if is_month %}Bản tháng{% else %}Bản tuần{% endif %}</strong>
-+                <div>{{ it.date | date: "%d/%m/%Y" }} · {{ it.title }}</div>
-+              </div>
-+            </div>
-+          {%- endfor -%}
-+        {%- else -%}
-+          <div class="timeline__item"><i class="ph ph-info"></i> Chưa có dữ liệu mới.</div>
-+        {%- endif -%}
-+      </div>
+    <div class="hero__panel">
+      <div class="panel__title">
+        <span><i class="ph ph-calendar-check"></i> Chọn bản tin</span>
+        <div class="mode-toggle" role="group" aria-label="Chế độ hiển thị">
+          <button type="button" id="btnCompact" aria-pressed="false" data-mode="compact"><i class="ph ph-device-mobile"></i> Compact</button>
+          <button type="button" id="btnComfort" aria-pressed="true" data-mode="comfort"><i class="ph ph-desktop-tower"></i> Comfort</button>
+        </div>
+      </div>
+      <div class="timeline" id="issueTimeline">
+        {%- if issues.size > 0 -%}
+          {%- for it in issues limit:4 -%}
+            {%- assign is_month = it.type == "month" or it.layout == "month" -%}
+            <div class="timeline__item">
+              <i class="ph ph-caret-right"></i>
+              <div>
+                <strong>{% if is_month %}Bản tháng{% else %}Bản tuần{% endif %}</strong>
+                <div>{{ it.date | date: "%d/%m/%Y" }} · {{ it.title }}</div>
+              </div>
+            </div>
+          {%- endfor -%}
+        {%- else -%}
+          <div class="timeline__item"><i class="ph ph-info"></i> Chưa có dữ liệu mới.</div>
+        {%- endif -%}
+      </div>
      </div>
    </header>
  
--  {%- assign list_months = site.months | sort: "date" | reverse -%}
--  {%- if site.weeks -%}
--    {%- assign list_weeks = site.weeks | sort: "date" | reverse -%}
--  {%- else -%}
--    {%- assign list_weeks = "" | split: "" -%}
--  {%- endif -%}
--  {%- assign issues = list_months | concat: list_weeks -%}
-+  <section class="issue-section">
-+    <div>
-+      {%- if issues.size > 0 -%}
-+      <div class="issue-grid" id="issueGrid">
-+        {%- for it in issues -%}
-+          {%- assign is_month = it.type == "month" or it.layout == "month" -%}
-+          {%- assign raw_excerpt = it.excerpt | strip_html | strip -%}
-+          {%- if raw_excerpt == "" -%}
-+            {%- assign raw_excerpt = it.content | strip_html | strip -%}
-+          {%- endif -%}
-+          {%- assign short_excerpt = raw_excerpt | replace: "\n", " " | replace: "  ", " " | truncate: 140 -%}
-+          <a class="issue-card"
-+             data-href="{{ it.url | relative_url }}"
-+             data-title="{{ it.title | escape }}"
-+             data-date="{{ it.date | date: '%d/%m/%Y' }}"
-+             data-type="{% if is_month %}month{% else %}week{% endif %}"
-+             data-period="{{ it.period | default: '' | escape }}"
-+             data-updated="{{ it.updated | default: '' | escape }}"
-+             data-org="{{ it.org | default: '' | escape }}">
-+            <div class="issue-card__meta">
-+              <span class="issue-card__type"><i class="ph ph-calendar"></i>
-+                {% if is_month %}
-+                  Tháng {% if it.period %}{{ it.period }}{% else %}{{ it.date | date: '%m/%Y' }}{% endif %}
-+                {% else %}
-+                  Tuần {% if it.period %}{{ it.period }}{% else %}{{ it.date | date: '%d/%m' }}{% endif %}
-+                {% endif %}
-+              </span>
-+              <span>{{ it.date | date: "%d/%m/%Y" }}</span>
-+            </div>
-+            <h3 class="issue-card__title">{{ it.title }}</h3>
-+            <p class="issue-card__desc">{{ short_excerpt }}</p>
-+          </a>
-+        {%- endfor -%}
-+      </div>
-+      {%- else -%}
-+      <div class="empty-state"><i class="ph ph-tray"></i> Chưa có bản tin nào. Vui lòng thêm nội dung trong thư mục <code>_months</code> hoặc <code>_weeks</code>.</div>
-+      {%- endif -%}
-+    </div>
+  <section class="issue-section">
+    <div>
+      {%- if issues.size > 0 -%}
+      <div class="issue-grid" id="issueGrid">
+        {%- for it in issues -%}
+          {%- assign is_month = it.type == "month" or it.layout == "month" -%}
+          {%- assign raw_excerpt = it.excerpt | strip_html | strip -%}
+          {%- if raw_excerpt == "" -%}
+            {%- assign raw_excerpt = it.content | strip_html | strip -%}
+          {%- endif -%}
+          {%- assign short_excerpt = raw_excerpt | replace: "\n", " " | replace: "  ", " " | truncate: 140 -%}
+          <a class="issue-card"
+             data-href="{{ it.url | relative_url }}"
+             data-title="{{ it.title | escape }}"
+             data-date="{{ it.date | date: '%d/%m/%Y' }}"
+             data-type="{% if is_month %}month{% else %}week{% endif %}"
+             data-period="{{ it.period | default: '' | escape }}"
+             data-updated="{{ it.updated | default: '' | escape }}"
+             data-org="{{ it.org | default: '' | escape }}">
+            <div class="issue-card__meta">
+              <span class="issue-card__type"><i class="ph ph-calendar"></i>
+                {% if is_month %}
+                  Tháng {% if it.period %}{{ it.period }}{% else %}{{ it.date | date: '%m/%Y' }}{% endif %}
+                {% else %}
+                  Tuần {% if it.period %}{{ it.period }}{% else %}{{ it.date | date: '%d/%m' }}{% endif %}
+                {% endif %}
+              </span>
+              <span>{{ it.date | date: "%d/%m/%Y" }}</span>
+            </div>
+            <h3 class="issue-card__title">{{ it.title }}</h3>
+            <p class="issue-card__desc">{{ short_excerpt }}</p>
+          </a>
+        {%- endfor -%}
+      </div>
+      {%- else -%}
+      <div class="empty-state"><i class="ph ph-tray"></i> Chưa có bản tin nào. Vui lòng thêm nội dung trong thư mục <code>_months</code> hoặc <code>_weeks</code>.</div>
+      {%- endif -%}
+    </div>
  
--  <!-- Grid thẻ báo cáo -->
--  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" id="cards">
--    {%- for it in issues -%}
--      {%- assign is_month = it.type == "month" or it.layout == "month" -%}
--      <a class="card block hover:shadow-xl transition" data-href="{{ it.url | relative_url }}" data-title="{{ it.title | escape }}">
--        <div class="flex items-center gap-2 text-sm text-emerald-800">
--          <span class="badge"><i class="ph ph-calendar-check"></i> {% if is_month %}Tháng{% else %}Tuần{% endif %}</span>
--          <span class="text-emerald-700">{{ it.date | date: "%d/%m/%Y" }}</span>
-+    <aside>
-+      <div class="viewer" id="viewer">
-+        <div class="viewer__header">
-+          <div class="viewer__title"><i class="ph ph-newspaper"></i> Nội dung nhanh</div>
-+          <div class="viewer__meta" id="viewerMeta"></div>
+    <aside>
+      <div class="viewer" id="viewer">
+        <div class="viewer__header">
+          <div class="viewer__title"><i class="ph ph-newspaper"></i> Nội dung nhanh</div>
+          <div class="viewer__meta" id="viewerMeta"></div>
          </div>
--        <h3 class="mt-2 font-extrabold text-emerald-900 leading-snug">{{ it.title }}</h3>
--        <p class="text-emerald-700 text-sm mt-1 line-clamp-2">Infographic + biểu đồ + nguồn dính số liệu.</p>
--      </a>
--    {%- endfor -%}
--  </div>
--
--  <!-- Khung xem nhanh -->
--  <div id="viewer" class="viewer mt-5">
--    <div class="inner" id="viewerInner">
--      <div class="skeleton" style="width:62%"></div>
--      <div class="skeleton" style="width:86%"></div>
--      <div class="skeleton" style="width:73%"></div>
--    </div>
--  </div>
-+        <div class="inner" id="viewerInner">
-+          <div class="skeleton" style="width:62%"></div>
-+          <div class="skeleton" style="width:86%"></div>
-+          <div class="skeleton" style="width:73%"></div>
-+        </div>
-+      </div>
-+    </aside>
-+  </section>
+        <div class="inner" id="viewerInner">
+          <div class="skeleton" style="width:62%"></div>
+          <div class="skeleton" style="width:86%"></div>
+          <div class="skeleton" style="width:73%"></div>
+        </div>
+      </div>
+    </aside>
+  </section>
  </div>
  
  <script>
  (function(){
--  // Toggle view-mode
--  const b=document.body, m=document.getElementById('btnMobile'), d=document.getElementById('btnDesktop');
--  const set=c=>{b.classList.toggle('compact',c); m.setAttribute('aria-pressed',c); d.setAttribute('aria-pressed',!c); localStorage.setItem('view-mode',c?'compact':'desktop')};
--  set((localStorage.getItem('view-mode')||'')==='compact' || window.innerWidth<768);
--  m.onclick=()=>set(true); d.onclick=()=>set(false);
-+  const body=document.body;
-+  const modeButtons=document.querySelectorAll('[data-mode]');
-+  const viewer=document.getElementById('viewerInner');
-+  const viewerMeta=document.getElementById('viewerMeta');
-+  const cardsWrap=document.getElementById('issueGrid');
-+  let activeCard=null;
+  const body=document.body;
+  const modeButtons=document.querySelectorAll('[data-mode]');
+  const viewer=document.getElementById('viewerInner');
+  const viewerMeta=document.getElementById('viewerMeta');
+  const cardsWrap=document.getElementById('issueGrid');
+  let activeCard=null;
  
--  // SPA loader
--  const viewer = document.getElementById('viewerInner');
--  const cards  = document.getElementById('cards');
-+  function setMode(mode){
-+    const isCompact=mode==='compact';
-+    body.classList.toggle('mode-compact',isCompact);
-+    modeButtons.forEach(btn=>{
-+      const pressed=btn.dataset.mode===mode;
-+      btn.setAttribute('aria-pressed',pressed);
-+    });
-+    localStorage.setItem('view-mode', isCompact ? 'compact' : 'comfort');
-+  }
-+
-+  const stored=(localStorage.getItem('view-mode')||'').toLowerCase();
-+  if(stored==='compact' || window.innerWidth<760){
-+    setMode('compact');
-+  }
-+
-+  modeButtons.forEach(btn=>{
-+    btn.addEventListener('click',()=>setMode(btn.dataset.mode));
-+  });
-+
-+  async function loadIssue(card){
-+    if(!card) return;
-+    if(activeCard) activeCard.classList.remove('is-active');
-+    activeCard=card;
-+    activeCard.classList.add('is-active');
-+    const url=card.getAttribute('data-href');
-+    const date=card.getAttribute('data-date');
-+    const type=card.getAttribute('data-type');
-+    const period=card.getAttribute('data-period');
-+    const updated=card.getAttribute('data-updated');
-+    const org=card.getAttribute('data-org');
+  function setMode(mode){
+    const isCompact=mode==='compact';
+    body.classList.toggle('mode-compact',isCompact);
+    modeButtons.forEach(btn=>{
+      const pressed=btn.dataset.mode===mode;
+      btn.setAttribute('aria-pressed',pressed);
+    });
+    localStorage.setItem('view-mode', isCompact ? 'compact' : 'comfort');
+  }
+
+  const stored=(localStorage.getItem('view-mode')||'').toLowerCase();
+  if(stored==='compact' || window.innerWidth<760){
+    setMode('compact');
+  }
+
+  modeButtons.forEach(btn=>{
+    btn.addEventListener('click',()=>setMode(btn.dataset.mode));
+  });
+
+  async function loadIssue(card){
+    if(!card) return;
+    if(activeCard) activeCard.classList.remove('is-active');
+    activeCard=card;
+    activeCard.classList.add('is-active');
+    const url=card.getAttribute('data-href');
+    const date=card.getAttribute('data-date');
+    const type=card.getAttribute('data-type');
+    const period=card.getAttribute('data-period');
+    const updated=card.getAttribute('data-updated');
+    const org=card.getAttribute('data-org');
  
--  async function loadIssue(url){
--    viewer.innerHTML = `
-+    const metaParts=[];
-+    if(period){
-+      if(type==='month') metaParts.push(`Kỳ: ${period}`);
-+      else metaParts.push(`Tuần: ${period}`);
-+    }
-+    if(date) metaParts.push(`Phát hành: ${date}`);
-+    if(updated) metaParts.push(`Cập nhật: ${updated}`);
-+    if(org) metaParts.push(org);
-+    viewerMeta.textContent = metaParts.join(' · ');
-+    viewer.innerHTML=`
+    const metaParts=[];
+    if(period){
+      if(type==='month') metaParts.push(`Kỳ: ${period}`);
+      else metaParts.push(`Tuần: ${period}`);
+    }
+    if(date) metaParts.push(`Phát hành: ${date}`);
+    if(updated) metaParts.push(`Cập nhật: ${updated}`);
+    if(org) metaParts.push(org);
+    viewerMeta.textContent = metaParts.join(' · ');
+    viewer.innerHTML=`
        <div class="skeleton" style="width:62%"></div>
        <div class="skeleton" style="width:86%"></div>
        <div class="skeleton" style="width:73%"></div>`;
--    try{
--      const res = await fetch(url, {headers:{'x-requested-with':'fetch'}});
--      const html = await res.text();
--      const doc  = new DOMParser().parseFromString(html,'text/html');
--      const root = doc.querySelector('#issue-root') || doc.body;
--      viewer.innerHTML = root.innerHTML;
  
--      // Re-render Mermaid inside viewer
-+    try{
-+      const res=await fetch(url,{headers:{'x-requested-with':'fetch'}});
-+      if(!res.ok) throw new Error(res.statusText);
-+      const html=await res.text();
-+      const doc=new DOMParser().parseFromString(html,'text/html');
-+      const root=doc.querySelector('#issue-root')||doc.body;
-+      viewer.innerHTML=root.innerHTML;
-+      // re-render mermaid
+    try{
+      const res=await fetch(url,{headers:{'x-requested-with':'fetch'}});
+      if(!res.ok) throw new Error(res.statusText);
+      const html=await res.text();
+      const doc=new DOMParser().parseFromString(html,'text/html');
+      const root=doc.querySelector('#issue-root')||doc.body;
+      viewer.innerHTML=root.innerHTML;
+      // re-render mermaid
        if(window.mermaid){
          mermaid.initialize({ startOnLoad:false, securityLevel:'loose' });
--        const codes = viewer.querySelectorAll('pre code.language-mermaid, pre code.mermaid');
-+        const codes=viewer.querySelectorAll('pre code.language-mermaid, pre code.mermaid');
+        const codes=viewer.querySelectorAll('pre code.language-mermaid, pre code.mermaid');
          codes.forEach((code,i)=>{
--          const src = code.textContent.trim();
--          const pre = code.closest('pre');
--          const container = document.createElement('div');
-+          const src=code.textContent.trim();
-+          const pre=code.closest('pre');
-+          const container=document.createElement('div');
+          const src=code.textContent.trim();
+          const pre=code.closest('pre');
+          const container=document.createElement('div');
            container.className='my-4';
--          pre?.parentNode?.replaceChild(container, pre);
--          try{ mermaid.render('mmdi-'+i, src, svg => container.innerHTML = svg); }
--          catch(e){ container.innerHTML='<pre>'+src.replace(/</g,'&lt;')+'</pre>'; }
-+          pre?.parentNode?.replaceChild(container,pre);
-+          try{mermaid.render('mmdi-'+i,src,svg=>container.innerHTML=svg);}catch(e){container.innerHTML='<pre>'+src.replace(/</g,'&lt;')+'</pre>';}
+          pre?.parentNode?.replaceChild(container,pre);
+          try{mermaid.render('mmdi-'+i,src,svg=>container.innerHTML=svg);}catch(e){container.innerHTML='<pre>'+src.replace(/</g,'&lt;')+'</pre>';}
          });
        }
--      window.scrollTo({top:0, behavior:'smooth'});
--    }catch(e){
--      viewer.innerHTML='<div style="padding:12px;color:#b91c1c">Không tải được nội dung. Vui lòng thử lại.</div>';
-+      window.scrollTo({top:0,behavior:'smooth'});
-+    }catch(err){
-+      console.error(err);
-+      viewer.innerHTML='<div style="padding:18px;color:#b91c1c;font-weight:600">Không tải được nội dung. Vui lòng thử lại.</div>';
-+      viewerMeta.textContent='';
+      window.scrollTo({top:0,behavior:'smooth'});
+    }catch(err){
+      console.error(err);
+      viewer.innerHTML='<div style="padding:18px;color:#b91c1c;font-weight:600">Không tải được nội dung. Vui lòng thử lại.</div>';
+      viewerMeta.textContent='';
      }
    }
  
--  // click cards (load tại chỗ)
--  cards.addEventListener('click', (ev)=>{
--    const a = ev.target.closest('[data-href]');
--    if(!a) return;
--    ev.preventDefault();
--    loadIssue(a.getAttribute('data-href'));
--  });
-+  if(cardsWrap){
-+    cardsWrap.addEventListener('click',ev=>{
-+      const card=ev.target.closest('[data-href]');
-+      if(!card) return;
-+      ev.preventDefault();
-+      loadIssue(card);
-+    });
+  if(cardsWrap){
+    cardsWrap.addEventListener('click',ev=>{
+      const card=ev.target.closest('[data-href]');
+      if(!card) return;
+      ev.preventDefault();
+      loadIssue(card);
+    });
  
--  // auto load số mới nhất
--  const first = cards.querySelector('[data-href]');
--  if(first) loadIssue(first.getAttribute('data-href'));
-+    const firstCard=cardsWrap.querySelector('[data-href]');
-+    if(firstCard){
-+      loadIssue(firstCard);
-+    }else{
-+      viewer.innerHTML='<div style="padding:18px;color:#0f172a;opacity:.75">Thêm bản tin để hiển thị nội dung ở đây.</div>';
-+    }
-+  }
+    const firstCard=cardsWrap.querySelector('[data-href]');
+    if(firstCard){
+      loadIssue(firstCard);
+    }else{
+      viewer.innerHTML='<div style="padding:18px;color:#0f172a;opacity:.75">Thêm bản tin để hiển thị nội dung ở đây.</div>';
+    }
+  }
  })();
  </script>
  </body>
  </html>
  
-EOF
-)


### PR DESCRIPTION
## Summary
- restore the YAML front matter delimiters around the homepage metadata so Jekyll processes the Liquid template

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e628cf1bf8832bb74ebb0e719bb45e