### PR TITLE
Fix homepage permalink handling to avoid duplicating baseurl

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@ index a8a1980d4389dd11d4baa138a8462947f8c45ed9..70e57c1cbc3d455b219e94ff46a192a6
  ---
 -layout: none
 +layout: null
-+permalink: /
  ---
 +{%- assign list_months = site.months | sort: "date" | reverse -%}
 +{%- if site.weeks -%}


### PR DESCRIPTION
## Summary
- remove the homepage permalink override so the built site uses the configured baseurl

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e629c6287c832bbc2f2316b35ad899