### PR TITLE
Align Gemfile with GitHub Pages dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source "https://rubygems.org"
 
-# Static site build dependencies
-gem "jekyll", "~> 4.3.3"
+# Use the dependency set that GitHub Pages supports so the site builds
+# identically locally and in production.
+gem "github-pages", "~> 231", group: :jekyll_plugins
+
+# `jekyll serve` still depends on Webrick when run locally.
 gem "webrick", "~> 1.8"
-gem "kramdown-parser-gfm", "~> 1.1"


### PR DESCRIPTION
## Summary
- replace the direct Jekyll dependency with the `github-pages` meta gem so the build matches the Pages environment
- keep the Webrick dependency for local `jekyll serve`

## Testing
- not run (network access to rubygems.org is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e63000b024832bb1950ca97550c0cd